### PR TITLE
Update `octaveperlin`

### DIFF
--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -4,11 +4,12 @@ using Random
 
 on_CI = haskey(ENV, "GITHUB_ACTIONS")
 
-x, y, z = rand(MersenneTwister(1234), Float32, 3)
+T = Float32
+x, y, z = rand(MersenneTwister(1234), T, 3)
 
 # Define benchmark
 SUITE = BenchmarkGroup()
 SUITE["Perlin"] = BenchmarkGroup(["noise", "perlin"])
 SUITE["Perlin"]["3D"] = BenchmarkGroup(["3d"])
 SUITE["Perlin"]["3D"]["perlin"] = @benchmarkable perlin($x, $y, $z)
-SUITE["Perlin"]["3D"]["octaveperlin"] = @benchmarkable octaveperlin($x, $y, $z, $3, $2.0f0)
+SUITE["Perlin"]["3D"]["octaveperlin"] = @benchmarkable octaveperlin($8, $T(2.0), $x, $y, $z)

--- a/src/perlin.jl
+++ b/src/perlin.jl
@@ -66,12 +66,12 @@ function perlin(x::T, y::T, z::T) where {T<:AbstractFloat}
 end
 
 function octaveperlin(
-    x::T, y::T, z::T, octaves::Int, persistence::T
+    octaves::Int, persistence::T, x::T, y::T, z::T
 ) where {T<:AbstractFloat}
-    total = 0.0
-    frequency = 1.0
-    amplitude = 1.0
-    maxval = 0.0
+    total = zero(T)
+    frequency = oneunit(T)
+    amplitude = oneunit(T)
+    maxval = zero(T)
     for _ in 1:octaves
         total += perlin(x * frequency, y * frequency, z * frequency) * amplitude
         maxval += amplitude

--- a/test/test_perlin.jl
+++ b/test/test_perlin.jl
@@ -1,7 +1,23 @@
 using Random
 
-x, y, z = rand(MersenneTwister(1234), Float32, 3)
+T = Float32
+x, y, z = rand(MersenneTwister(1234), T, 3)
 
-# Dryrun
 n = @inferred perlin(x, y, z)
+@test typeof(n) == T
 @test n ≈ 0.547249
+
+n = @inferred octaveperlin(8, T(1.0), x, y, z)
+@test typeof(n) == T
+@test n ≈ 0.47737733
+
+T = Float16
+x, y, z = rand(MersenneTwister(1234), T, 3)
+
+n = @inferred perlin(x, y, z)
+@test typeof(n) == T
+@test n ≈ 0.3982
+
+n = @inferred octaveperlin(8, T(1.0), x, y, z)
+@test typeof(n) == T
+@test n ≈ 0.4492


### PR DESCRIPTION
Update `octaveperlin` to return same type as input coordinates and change API to `octaveperlin(octaves, persistence, x, y, z)` in preparation of a generalized $n$-dimensional implementation with variable argument length.